### PR TITLE
Allow text to be selected by users on the documentation site

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -56,12 +56,10 @@ const Layout = ({ children }) => {
                     backgroundColor: theme.colors.background.default
                   },
                   body: {
-                    userSelect: "none",
                     margin: 0,
                     WebkitFontSmoothing: "antialiased"
                   },
                   "body *": {
-                    userSelect: "none",
                     WebkitTapHighlightColor: "transparent"
                   }
                 }}


### PR DESCRIPTION
Being able to select text on a web page is something I consider to be a basic expectation of web browsing.

Some of the useful things that selecting text allows me to do include:
- copy and paste a terminal command or code sample
- highlight or annotate part of the page with [hypothes.is](https://web.hypothes.is)

And I'm sure there are other uses I'm not even thinking of right now... :)